### PR TITLE
Fix typo in README.md: s/htime/hrtime/

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ triggered with different mechanisms. One can use
 
 # Time resolution
 
-[`process.htime()`](https://nodejs.org/api/process.html#process_process_hrtime_time)
+[`process.hrtime()`](https://nodejs.org/api/process.html#process_process_hrtime_time)
 is nanoseconds-precise on Unix but is 100 times less precise on Windows.
 
 # OS identification


### PR DESCRIPTION
Aside: even though `process.hrtime()` returns nanoseconds, the actual resolution is usually much coarser. On Linux, for example, it's usually no better than 100 ns (0.1 us) and often much worse. I wouldn't single out Windows.