### PR TITLE
Added 'aux' as a reserved Windows file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Portable filenames need to avoid:
   [those names](https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#naming-conventions):
   `com1`, `com2`, `com3`, `com4`, `com5`, `com6`, `com7`,
   `com8`, `com9`, `lpt1`, `lpt2`, `lpt3`, `lpt4`, `lpt5`,
-  `lpt6`, `lpt7`, `lpt8`, `lpt9`, `con`, `nul`, `prn`.
+  `lpt6`, `lpt7`, `lpt8`, `lpt9`, `con`, `nul`, `prn`, `aux`.
 
 Portable file paths need to avoid being
 [more than 260


### PR DESCRIPTION
As listed in the Windows file naming conventions (as [linked from the original document](https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#naming-conventions)), `aux` is also a reserved file name. This change makes the list of reserved names the same as the source.