### PR TITLE
Improve several points regarding Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,9 +379,13 @@ when it comes to naming files and paths.
 
 Portable filenames need to avoid:
 
-- any other characters but `a-z`, `0-9`, `-._,=()~`
+- any other characters but `a-z`, `0-9`, `-._,=()`
 - starting with `-`
 - ending with a `.`
+- [starting](https://support.microsoft.com/en-us/help/211632/description-of-how-word-creates-temporary-files)
+  or
+  [ending](https://vim.fandom.com/wiki/Remove_swap_and_backup_files_from_your_working_directory)
+  [with `~`](https://en.wikipedia.org/wiki/Home_directory#Unix).
 - uppercase characters (Mac and Windows are case-insensitive).
 - being more than 255 characters long.
 - being one of
@@ -399,8 +403,6 @@ Portable file paths need to avoid:
   [create issues](https://github.com/nodejs/node-v0.x-archive/issues/6960)
   with `npm` deeply nesting `node_modules` but not anymore with the latest
   `npm` versions.
-- use the `~` or `~user`
-  [home directory shorthand](https://en.wikipedia.org/wiki/Home_directory#Unix).
 
 # Shell
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ Typical directory locations are OS-specific:
 - the user's home directory could for example be `/home/USER` on Linux,
   `/Users/USER` on Mac or `C:\Users\USER` on Windows.
   [`os.homedir()`](https://nodejs.org/api/os.html#os_os_homedir) can be used
-  to retrieve it on any OS.
+  to retrieve it on any OS. Application-specific settings are stored into
+  [subdirectories on Windows](<https://msdn.microsoft.com/en-us/library/windows/desktop/bb776892(v=vs.85).aspx>):
+  `Roaming` (`APPDATA` environment variable) and `Local` (`LOCALAPPDATA`
+  environment variable).
 
 [Man pages](https://www.kernel.org/doc/man-pages/) are Unix-specific so the
 [`package.json`'s `man` field](https://docs.npmjs.com/files/package.json#man)

--- a/README.md
+++ b/README.md
@@ -136,16 +136,25 @@ as an admin before being able to install
 
 # Directory locations
 
-Typical directory locations are OS-specific:
+Typical directory locations are OS-specific.
 
-- the main temporary directory could for example be `/tmp` on Linux,
-  `/var/folders/.../T` on Mac or `C:\Users\USER\AppData\Local\Temp` on
-  Windows. [`os.tmpdir()`](https://nodejs.org/api/os.html#os_os_tmpdir) can be
-  used to retrieve it on any OS.
-- the user's home directory could for example be `/home/USER` on Linux,
-  `/Users/USER` on Mac or `C:\Users\USER` on Windows.
-  [`os.homedir()`](https://nodejs.org/api/os.html#os_os_homedir) can be used
-  to retrieve it on any OS. Application-specific settings are stored into
+The main temporary directory:
+
+- could for example be `/tmp` on Linux, `/var/folders/.../T` on Mac or
+  `C:\Users\USER\AppData\Local\Temp` on Windows.
+- [`os.tmpdir()`](https://nodejs.org/api/os.html#os_os_tmpdir) can be used to
+  retrieve it on any OS.
+- different terminal sessions on the same machine
+  [might have different temporary directories](https://github.com/ehmicky/portable-node-guide/pull/17#issuecomment-476209345)
+  on Windows.
+
+The user's home directory:
+
+- could for example be `/home/USER` on Linux, `/Users/USER` on Mac or
+  `C:\Users\USER` on Windows.
+- [`os.homedir()`](https://nodejs.org/api/os.html#os_os_homedir) can be used
+  to retrieve it on any OS.
+- application-specific settings are stored into
   [subdirectories on Windows](<https://msdn.microsoft.com/en-us/library/windows/desktop/bb776892(v=vs.85).aspx>):
   `Roaming` (`APPDATA` environment variable) and `Local` (`LOCALAPPDATA`
   environment variable).

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ configuration as files or remotely is easier and more portable.
 
 The [character encoding](https://en.wikipedia.org/wiki/Character_encoding) on
 Unix is usually [UTF-8](https://en.wikipedia.org/wiki/UTF-8). However on Windows
-it is usually either [UTF-16](https://en.wikipedia.org/wiki/UTF-16) or one of
+it can also be [UTF-16](https://en.wikipedia.org/wiki/UTF-16) or one of
 the [Windows code pages](https://en.wikipedia.org/wiki/Windows_code_page).
 Few non-[Unicode](https://unicode.org/) character encodings are also popular in
 some countries. This can result in characters not being printed properly,

--- a/README.md
+++ b/README.md
@@ -274,9 +274,10 @@ on some Windows commands when in text mode. This includes the
 [`type` command](https://ss64.com/nt/type.html) in `cmd.exe`. As a consequence
 that character should be avoided in non-binary files.
 
-As opposed to Windows, Unix does not implicitely add a newline at the end of
-files. Thus it is recommended to end files with a
-[newline character](#newlines). However please remember that Windows will print
+As opposed to Windows, Unix
+[requires text files](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)
+to end with a
+[newline character](#newlines). However please remember that Windows might print
 these as if two newlines were present instead.
 
 The [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) is a special character

--- a/README.md
+++ b/README.md
@@ -454,8 +454,8 @@ As a consequence it is recommended to:
 
 To decide which program should execute a file:
 
-- Unix uses [Shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) like
-  `#!/usr/bin/node`
+- Unix uses [shebangs](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) like
+  `#!/usr/bin/node`.
 - Windows uses
   [filename](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ftype)
   [extensions](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/assoc).

--- a/README.md
+++ b/README.md
@@ -603,7 +603,8 @@ properly work on Linux as they always reflect the
 The [`O_NOATIME`](https://nodejs.org/api/fs.html#fs_file_open_constants) flag
 of
 [`fs.open()`](https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback)
-only works on Linux.
+only works on Linux. Access times can also be disabled on Windows but through
+[the registry](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-behavior#remarks).
 
 [`fs.watch()`](https://nodejs.org/api/fs.html#fs_caveats) is not very portable.
 For example the option `recursive` does not work on Linux.

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ for the `PATH` environment variable.
 
 Finally most environment variables names are OS-specific:
 
-- `SHELL` on Unix is `ComSpec` on Windows. Unfortunately
+- `SHELL` on Unix is `ComSpec` on Windows.
   [`os.userInfo().shell`](https://nodejs.org/api/os.html#os_os_userinfo_options)
   returns `null` on Windows.
 - `PS1` on Unix is `PROMPT` on Windows.

--- a/README.md
+++ b/README.md
@@ -522,7 +522,8 @@ purpose:
 The syntax to
 [reference environment variables](https://ss64.com/nt/syntax-variables.html) is
 `$VARIABLE` on Unix but `%VARIABLE%` on Windows. Also if the variable is
-missing, its value will be `''` on Unix but `'%VARIABLE%'` on Windows.
+missing, its value will be `''` on Unix and in Windows batch files, but
+`'%VARIABLE%'` in `cmd.exe`.
 
 To pass
 [environment variables](https://docs.microsoft.com/en-us/windows/desktop/procthread/environment-variables)

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ Consequently all methods based on
 - [`fs.chown()`](https://nodejs.org/api/fs.html#fs_fs_chown_path_uid_gid_callback)
   does not do anything.
 
-The privileged user is `root` on Unix and `admin` on Windows. Those are
+The privileged user is `root` on Unix and `Administrator` on Windows. Those are
 triggered with different mechanisms. One can use
 [`is-elevated`](https://github.com/sindresorhus/is-elevated) (and the related
 [`is-admin`](https://github.com/sindresorhus/is-admin) and

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ When reading from a file or terminal, one should either:
 
 When writing to a terminal the character encoding will almost always be
 [UTF-8](https://en.wikipedia.org/wiki/UTF-8) on Unix and
-[CP866](https://en.wikipedia.org/wiki/Code_page_866) on Windows (`cmd.exe`).
+[CP437](https://en.wikipedia.org/wiki/Code_page_437) /
+[CP850](https://en.wikipedia.org/wiki/Code_page_850) on Windows (`cmd.exe`).
 [figures](https://github.com/sindresorhus/figures) and
 [log-symbols](https://github.com/sindresorhus/log-symbols) can be used to
 print common symbols consistently across platforms.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ When reading from a file or terminal, one should either:
 When writing to a terminal the character encoding will almost always be
 [UTF-8](https://en.wikipedia.org/wiki/UTF-8) on Unix and
 [CP437](https://en.wikipedia.org/wiki/Code_page_437) /
-[CP850](https://en.wikipedia.org/wiki/Code_page_850) on Windows (`cmd.exe`).
+[CP850](https://en.wikipedia.org/wiki/Code_page_850) /
+[Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) on Windows
+(`cmd.exe`).
 [figures](https://github.com/sindresorhus/figures) and
 [log-symbols](https://github.com/sindresorhus/log-symbols) can be used to
 print common symbols consistently across platforms.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Did you find an error or want to add more information?
 - [Processes](#processes)
 - [Signals](#signals)
 - [Errors](#errors)
-- [Anti-virus](#anti-virus)
 - [Summary](#summary)
 - [See also](#see-also)
 - [Support](#support)
@@ -655,6 +654,13 @@ Another difference on Windows: to execute files their extension must be listed
 in the environment variable
 [`PATHEXT`](http://environmentvariables.org/PathExt).
 
+Directories can
+[be locked](https://github.com/isaacs/node-graceful-fs/pull/97) on Windows
+which make erasing or removing them fail.
+[`graceful-fs`](https://github.com/isaacs/node-graceful-fs) or
+[`rimraf`](https://github.com/isaacs/rimraf) solves this by retrying few
+milliseconds later.
+
 Finally
 [`fs.lchmod()`](https://nodejs.org/api/fs.html#fs_fs_lchmod_path_mode_callback)
 is only available on Mac.
@@ -860,15 +866,6 @@ Most available `error.code`
 can be fired on any OS. However few
 [start with `W`](https://nodejs.org/api/os.html#os_windows_specific_error_constants)
 and can only be fired on Windows.
-
-# Anti-virus
-
-Some anti-virus software on Windows
-[have been reported](https://github.com/isaacs/node-graceful-fs/pull/97) to lock
-directories and make `fs.rename()` fail.
-[`graceful-fs`](https://github.com/isaacs/node-graceful-fs) or
-[`rimraf`](https://github.com/isaacs/rimraf) solves this by retrying few
-milliseconds later.
 
 # Summary
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ There are several approaches to solve this:
   - [`shelljs`](https://github.com/shelljs/shelljs)
   - [`node-windows`](https://github.com/coreybutler/node-windows)
 - some projects abstract common user applications:
-  - [`opn`](https://github.com/sindresorhus/opn) for opening files.
   - [`clipboard-cli`](https://github.com/sindresorhus/clipboard-cli) for
     copy/pasting.
 
@@ -454,13 +453,21 @@ As a consequence it is recommended to:
 
 # Files execution
 
-[Shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) like `#!/usr/bin/node`
-do not work on Windows, where only files ending with `.exe`, `.com`, `.cmd`
-or `.bat` can be directly executed. Portable file execution must either:
+To decide which program should execute a file:
 
-- use an interpreter, e.g. `node file.js` instead of `./file.js`.
+- Unix uses [Shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) like
+  `#!/usr/bin/node`
+- Windows uses
+  [filename](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ftype)
+  [extensions](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/assoc).
+
+Portable file execution must either:
+
+- explicitly specify the program, e.g. `node ./file.js` instead of `./file.js`.
 - use [`cross-spawn`](https://github.com/moxystudio/node-cross-spawn)
-  (which is included in [`execa`](https://github.com/sindresorhus/execa)).
+  (which is included in [`execa`](https://github.com/sindresorhus/execa))
+  which polyfills shebangs on Windows.
+- use [`opn`](https://github.com/sindresorhus/opn).
 
 During file execution the extension can be omitted on Windows if it is listed
 in the [`PATHEXT`](http://environmentvariables.org/PathExt) environment


### PR DESCRIPTION
**Which problem is this pull request solving?**

Some points regarding Windows are erroneous.

This was reported by @ayra [on Reddit](https://www.reddit.com/r/commandline/comments/b4xcvz/portable_nodejs_guide_including_crossplatform/ej9zr2c/).

Please note few points inside that Reddit comments have not been added because:
  - the guide already mentions them:
     - `Newlines in Windows are always CRLF, never just LF.`
     - `CTRL+Z does end streams in Windows but only in text mode, not when reading in binary mode.`
  - while this works on Windows, this does not lead to the best cross-platform behavior:
     - `While you should avoid common device names as file/directory names in Windows (COM1,COM2,etc.) you can use them normally using the long file name syntax \\?\`
     - `No reason to avoid uppercase characters on Windows.`
  - others:
     - `TCP servers can listen on a file descriptor in Windows` and `If you mean an internal socket by "File descriptor" this is done via anonymous or named pipes in Windows.`: see note at end of https://nodejs.org/api/net.html#net_server_listen_handle_backlog_callback

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
