### PR TITLE
Added link from 'time.md' to the "Terminal" index page

### DIFF
--- a/docs/system/time.md
+++ b/docs/system/time.md
@@ -6,4 +6,5 @@ is hardware-specific and varies between 1 nanosecond and 1 millisecond.
 
 <hr>
 
+[**Next** _(💻 Terminal)_](../terminal/README.md)<br>
 [**Previous** _(🎛️ Hardware)_](hardware.md)<br> [**Top**](README.md)<br>


### PR DESCRIPTION
Great project!

**Which problem is this pull request solving?**

Since at the end of every other section there is a link to the following "chapter", I thought I could add a link in the last page of the "System" chapter ([Time](https://github.com/ehmicky/cross-platform-node-guide/blob/4e65f336baff30ab38be5aef08853f80c398fef6/docs/system/time.md)) to the ["Terminal" chapter](https://github.com/ehmicky/cross-platform-node-guide/tree/4e65f336baff30ab38be5aef08853f80c398fef6/docs/terminal).

Let me know if it was wanted, or it just slipped by. 😃 

I also noticed that the ["Terminal" chapter](https://github.com/ehmicky/cross-platform-node-guide/tree/4e65f336baff30ab38be5aef08853f80c398fef6/docs/terminal) index page has the "Previous" link to the last page of the [File System chapter](https://github.com/ehmicky/cross-platform-node-guide/tree/4e65f336baff30ab38be5aef08853f80c398fef6/docs/filesystem). Do you want me to fix it as well?

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).